### PR TITLE
fix typo in manifest.toml.template

### DIFF
--- a/templates/go-templates/manifest.toml.template
+++ b/templates/go-templates/manifest.toml.template
@@ -30,5 +30,5 @@ instances = { min = 1, max = 5, default = 1 }
 # [[testcases]]
 # name = "another"
 # instances = { min = 1, max = 1, default = 1 }
-#   [testcase.params]
+#   [testcases.params]
 #   param1 = { type = "int", desc = "an integer", unit = "units", default = 3 }


### PR DESCRIPTION
With the typo tests would repetitively panic with something like `param1 was not set`