### PR TITLE
chore: fix template issue for quickstart tutorial

### DIFF
--- a/templates/go-templates/manifest.toml.template
+++ b/templates/go-templates/manifest.toml.template
@@ -23,7 +23,7 @@ enabled = true
 enabled = true
 
 [[testcases]]
-name= "quickstart"
+name = "quickstart"
 instances = { min = 1, max = 5, default = 1 }
 
 # Add more testcases here...


### PR DESCRIPTION
This little nit(no space in the template for `quickstart` testcase) can confuse future devs, who want to get acquainted with testground by going through this official [tutorial](https://docs.testground.ai/writing-test-plans/quickstart)

This fix will make the learning process less confused 